### PR TITLE
fix wrong readIO

### DIFF
--- a/rpcpackage.go
+++ b/rpcpackage.go
@@ -465,7 +465,15 @@ func (r *RpcDataPackage) ReadIO(rw io.Reader) error {
 	leftSize := totalSize
 	body := make([]byte, leftSize)
 
-	rw.Read(body)
+	// read all
+	receiveSize := 0
+	for receiveSize < int(leftSize) {
+		l, err := rw.Read(body[receiveSize:])
+		if err != nil {
+			return fmt.Errorf("Read body error %w ", err)
+		}
+		receiveSize += l
+	}
 
 	proto.Unmarshal(body[0:metaSize], r.Meta)
 


### PR DESCRIPTION
使用golang 版的 brpc客户端和c++b版本的服务端代码联调过程中发现，部分请求信息接收不全，从而导致数据序列化失败。
在代码中添加部分日志，发现接收到的数据后半段为全零，且问题未偶然出现，同时全零序列的长度并不固定。（附录1）
将失败的返回和成功返回的数据对比，发现长度一致，全零部分序列应为其他有意义的序列。
如果增加重试机制会发现，重试接收到的数据依然解析失败。但是，其头部序列刚好是全零序列缺失的部分。
猜测可能是接收过程中，rw.Read(body) 并未获得全部的数据。
提交的代码，已经在工程中验证通过。
